### PR TITLE
feat(ui): soften dark theme and refresh homepage intro

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -7,6 +7,12 @@
 #
 # The hook is tolerant: any failure is logged to stderr but never blocks the
 # commit. If the commit doesn't touch a post file, it's a no-op.
+#
+# Phase hook:
+# Set BLOG_TRACE_POSTS to a comma-separated post list and optionally set:
+# BLOG_TRACE_ROLE (default polish), BLOG_TRACE_HARNESS, BLOG_TRACE_KIND,
+# BLOG_TRACE_MARKER, BLOG_TRACE_NOTE to run a forced capture pass with this
+# metadata.
 set -uo pipefail
 
 changed=$(git show --no-renames --name-only --format='' HEAD | grep '^src/content/posts/.*\.mdx$' || true)
@@ -19,8 +25,50 @@ if ! command -v pnpm >/dev/null 2>&1; then
   exit 0
 fi
 
-pnpm tsx tools/trace-capture.ts capture --auto --role=polish \
-  2> >(sed 's/^/[trace-capture] /' >&2) || true
+BLOG_TRACE_POSTS="${BLOG_TRACE_POSTS:-}"
+BLOG_TRACE_HARNESS="${BLOG_TRACE_HARNESS:-}"
+BLOG_TRACE_ROLE="${BLOG_TRACE_ROLE:-polish}"
+BLOG_TRACE_KIND="${BLOG_TRACE_KIND:-post}"
+BLOG_TRACE_MARKER="${BLOG_TRACE_MARKER:-}"
+BLOG_TRACE_NOTE="${BLOG_TRACE_NOTE:-}"
+
+if [ -n "$BLOG_TRACE_POSTS" ]; then
+  IFS=',' read -r -a BLOG_POSTS <<< "$BLOG_TRACE_POSTS"
+  for post in "${BLOG_POSTS[@]}"; do
+    cmd=(pnpm tsx tools/trace-capture.ts capture --post="$post" --role="$BLOG_TRACE_ROLE" --kind="$BLOG_TRACE_KIND" --attach=revision --commit=HEAD)
+    if [ -n "$BLOG_TRACE_HARNESS" ]; then cmd+=(--harness="$BLOG_TRACE_HARNESS"); fi
+    if [ -n "$BLOG_TRACE_MARKER" ]; then cmd+=(--marker="$BLOG_TRACE_MARKER"); fi
+    if [ -n "$BLOG_TRACE_NOTE" ]; then cmd+=(--note="$BLOG_TRACE_NOTE"); fi
+    "${cmd[@]}" 2> >(sed 's/^/[trace-capture] /' >&2) || true
+  done
+fi
+
+if [ -n "$BLOG_TRACE_POSTS" ]; then
+  # Forced capture handled this commit.
+  exit 0
+fi
+
+# Decide path: agent vs human.
+# Heuristic: if the env signals an active agent (CLAUDECODE, CLAUDE_PROJECT_DIR,
+# CODEX_HOME, or a recent ~/.claude/projects session within 10min), prefer
+# trace-capture. Otherwise, log a human revision.
+AGENT=0
+if [ -n "${CLAUDECODE:-}" ] || [ -n "${CLAUDE_PROJECT_DIR:-}" ] || [ -n "${CODEX_HOME:-}" ]; then
+  AGENT=1
+fi
+
+# Recent claude-code session within 10 minutes also counts.
+if [ "$AGENT" = "0" ] && [ -d "$HOME/.claude/projects" ]; then
+  if find "$HOME/.claude/projects" -name '*.jsonl' -mmin -10 2>/dev/null | grep -q .; then
+    AGENT=1
+  fi
+fi
+
+if [ "$AGENT" = "1" ]; then
+  pnpm tsx tools/trace-capture.ts capture --auto --role=polish --kind=post --attach=revision 2> >(sed 's/^/[trace-capture] /' >&2) || true
+else
+  node tools/log-edit.mjs --auto || true
+fi
 
 # Amend the commit to include new trace files + frontmatter updates if any.
 if ! git diff --quiet src/content/posts traces 2>/dev/null; then

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -90,7 +90,7 @@ const websiteJsonLd = isHome
     <meta name="twitter:image" content={ogImage} />
 
     <meta name="author" content="Drew Stone" />
-    <meta name="theme-color" content="#0d0d0d" />
+    <meta name="theme-color" content="#131120" />
 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="sitemap" href="/sitemap-index.xml" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -45,6 +45,7 @@ function fmtMonth(d: Date) {
 <Base title="drew" description="Drew Stone's blog. AI and autoresearch infrastructure: sandboxes for agents, eval harnesses, optimization loops. Plus crypto: stablecoin payments and privacy. A live experiment in human–AI co-authorship." wide>
   <section class="hero">
     <div class="intro">
+      <p class="intro-kicker">AI infrastructure, crypto, and experiment-led research</p>
       <p class="intro-lead">
         Hi, I'm <strong>Drew</strong>. I work on AI and autoresearch infrastructure at
         <a href="https://tangle.tools">Tangle</a>: <strong>sandboxes for agents</strong>,
@@ -65,6 +66,11 @@ function fmtMonth(d: Date) {
         they surface with an <em>Original</em> badge, and AI agents are forbidden from
         editing them.
       </p>
+      <div class="intro-actions">
+        <a class="intro-chip" href="/posts">Read latest posts</a>
+        <a class="intro-chip" href="/traces">Inspect traces</a>
+        <a class="intro-chip" href="/experiment">Experiment log</a>
+      </div>
     </div>
     <aside class="hero-side">
       <div class="hero-side-head">
@@ -123,25 +129,36 @@ function fmtMonth(d: Date) {
 </script>
 
 <style>
-  /* ===== Hero: side-by-side intro + newest ===== */
+  /* ===== Hero: narrative + compact newest rail ===== */
   .hero {
     display: grid;
-    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
-    gap: 3rem;
+    grid-template-columns: 1fr;
+    gap: 1.4rem;
     align-items: start;
     margin: var(--space-lg) 0 var(--space-2xl);
     padding-bottom: var(--space-xl);
     border-bottom: 1px dotted var(--border);
   }
 
-  @media (max-width: 880px) {
-    .hero { grid-template-columns: 1fr; gap: 1.8rem; }
+  @media (min-width: 900px) {
+    .hero {
+      grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+      gap: 2.2rem;
+    }
   }
 
   /* ===== Intro block ===== */
   .intro {
     margin: 0;
     max-width: none;
+  }
+  .intro-kicker {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--fg-faint);
+    margin-bottom: 0.7rem;
   }
   .intro p {
     font-size: 1.08rem;
@@ -181,6 +198,28 @@ function fmtMonth(d: Date) {
   .intro a:hover {
     text-decoration-color: var(--c-action);
   }
+  .intro-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0 var(--space-md);
+  }
+  .intro-chip {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.33rem 0.72rem;
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-faint);
+    text-decoration: none;
+    transition: border-color 0.2s ease, color 0.2s ease;
+  }
+  .intro-chip:hover {
+    border-color: var(--fg-faint);
+    color: var(--fg);
+  }
 
   /* ===== Inline experiment lede — second paragraph in the intro column ===== */
   .experiment-lede {
@@ -208,14 +247,14 @@ function fmtMonth(d: Date) {
   .experiment-lede a:hover { text-decoration-color: var(--c-action); }
   .experiment-lede strong { font-weight: 700; }
   .experiment-lede-human {
-    color: #00b347;
+    color: var(--c-human);
     font-weight: 700;
     font-style: italic;
   }
   @media (prefers-color-scheme: dark) {
     .experiment-lede-human {
-      color: #39ff88;
-      text-shadow: 0 0 12px rgba(57, 255, 136, 0.45);
+      color: #68f5b6;
+      opacity: 0.95;
     }
   }
   .experiment-stats .stats-human span { color: var(--c-human); opacity: 0.8; }
@@ -223,7 +262,11 @@ function fmtMonth(d: Date) {
   /* ===== Newest side column ===== */
   .hero-side {
     min-width: 0;
-    padding-top: 0.25rem;
+    padding-top: 0;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 0.95rem 1rem 1rem;
+    background: color-mix(in srgb, var(--bg-alt) 72%, transparent);
   }
   .hero-side-head {
     display: flex;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -50,16 +50,16 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #0d0d0d;
-    --bg-alt: #1f1f1f;
-    --bg-sink: #050505;
-    --fg: #eaeaea;
-    --fg-muted: #b0b0b0;
+    --bg: #131120;
+    --bg-alt: #1e1a2d;
+    --bg-sink: #0c0a16;
+    --fg: #ece8f7;
+    --fg-muted: #b4adca;
     --fg-faint: #7a7a7a;
-    --border: #333333;
-    --border-strong: #555555;
-    --rule: #eaeaea;
-    --accent: #eaeaea;
+    --border: #2f2a44;
+    --border-strong: #4f4768;
+    --rule: #9f97b6;
+    --accent: #ece8f7;
 
     --c-ok: #4ade80;
     --c-ok-bg: rgba(74, 222, 128, 0.12);
@@ -78,6 +78,15 @@
     --c-human: #34d399;
     --c-human-bg: rgba(52, 211, 153, 0.12);
     --c-human-border: rgba(52, 211, 153, 0.35);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background:
+      radial-gradient(circle at 7% -10%, rgba(76, 68, 113, 0.2), transparent 35%),
+      radial-gradient(circle at 93% 8%, rgba(63, 55, 102, 0.18), transparent 38%),
+      var(--bg);
   }
 }
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -35,8 +35,14 @@ pnpm blog finish long-running-task-systems --research --harness=codex --note="su
 # Print the exact prompt to paste into a thread that may write/edit the post.
 pnpm blog write long-running-task-systems --harness=codex --role=draft
 
+# Optionally tag a single phase in a single session.
+pnpm blog write long-running-task-systems --harness=codex --role=publish --marker="[BLOG_TRACE_MARKER:publish]"
+
 # In that thread, the agent may edit the post and then records an authorship trace:
 pnpm blog finish long-running-task-systems --write --harness=codex --role=draft --note="drafted benchmark section"
+
+# For a final publish phase in the same session:
+pnpm blog finish long-running-task-systems --write --harness=codex --role=publish --marker="[BLOG_TRACE_MARKER:publish]" --note="published by toggling draft=false"
 ```
 
 Research traces go into `supporting_trace_ids`. They are rendered as "Supporting research" and do not imply authorship. Writing traces go into `revisions[]` and do imply AI authorship/editing.
@@ -64,6 +70,7 @@ Extracts the agent session behind a revision and writes it to `traces/<slug>/<tr
 pnpm tsx tools/trace-capture.ts capture \
   --harness=claude-code \
   --post=convergence-as-eval-primitive \
+  --marker="[BLOG_TRACE_MARKER:publish]" \
   --role=polish
 
 # Auto-detect from the latest commit: finds changed posts, matches sessions
@@ -94,6 +101,27 @@ chmod +x .githooks/post-commit
 ```
 
 After that, every commit that touches a post under `src/content/posts/` triggers `trace-capture.ts capture --auto`, appends the revision entry, adds the new trace file, and amends the commit. Failures are non-blocking and logged to stderr.
+
+### Session directive path for AI phase marking
+
+For a publish/review/finalization phase in one AI session, set hook directives so capture is pinned to a specific phase token.
+
+```bash
+BLOG_TRACE_POSTS=long-running-task-systems \
+BLOG_TRACE_ROLE=publish \
+BLOG_TRACE_KIND=post \
+BLOG_TRACE_MARKER="[BLOG_TRACE_MARKER:publish]" \
+BLOG_TRACE_NOTE="published with AI-assisted finalization" \
+git commit -am "publish final copy"
+```
+
+Hook variables:
+- `BLOG_TRACE_POSTS`: comma-separated slugs (required for forced capture)
+- `BLOG_TRACE_ROLE`: `draft`, `publish`, `polish`, etc.
+- `BLOG_TRACE_KIND`: `post` or `series-outline`
+- `BLOG_TRACE_MARKER`: token expected in the final user turn
+- `BLOG_TRACE_NOTE`: optional revision note
+- `BLOG_TRACE_HARNESS`: optional `codex` or `claude-code`
 
 ## `feedback-eval.ts` — content scorecard
 

--- a/tools/blog-loop.mjs
+++ b/tools/blog-loop.mjs
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   pnpm blog research <post> [--harness=codex|claude-code]
- *   pnpm blog write <post> [--harness=codex|claude-code] [--role=draft|rewrite|polish|outline|review|publish]
+ *   pnpm blog write <post> [--harness=codex|claude-code] [--role=draft|rewrite|polish|outline|review|publish] [--marker=<token>]
  *   pnpm blog finish <post> --research --harness=codex --note="source scan"
  *   pnpm blog finish <post> --write --harness=codex --note="drafted section"
  */
@@ -68,16 +68,34 @@ function resolvePost(all, query) {
   return null
 }
 
-function printPrompt(mode, post, harness, role) {
+function printPrompt(mode, post, harness, role, marker) {
   const finish = mode === 'research'
     ? `pnpm blog finish ${post.slug} --research --harness=${harness} --note="<what this research covered>"`
-    : `pnpm blog finish ${post.slug} --write --harness=${harness} --role=${role} --note="<what changed>"`
+    : `pnpm blog finish ${post.slug} --write --harness=${harness} --role=${role} --note="<what changed>"${marker ? ` --marker="${marker}"` : ''}`
 
   const prompt = mode === 'research'
     ? `This is supporting research for the blog post "${post.title}" (${post.slug}). Do not edit the post. Do not write prose for publication. Mine sources, claims, open questions, counterarguments, and useful Q/A. At the end, run: ${finish}`
     : `This is authorship work for the blog post "${post.title}" (${post.slug}). You may edit src/content/posts/${post.slug}.mdx unless it has original: true. Preserve provenance fields. At the end, run: ${finish}`
 
-  console.log(prompt)
+  const markerLine = marker
+    ? `\nFinal phase marker: include this exact token in the final user message before finishing: ${marker}`
+    : ''
+
+  if (marker) {
+    const shellToken = marker.replace(/"/g, '\\"')
+    const directive = [
+      `BLOG_TRACE_POSTS=${post.slug}`,
+      `BLOG_TRACE_ROLE=${role}`,
+      `BLOG_TRACE_MARKER="${shellToken}"`,
+      'BLOG_TRACE_KIND=post',
+      `BLOG_TRACE_NOTE="session ${role} marker"`,
+    ].join(' ')
+    const directiveLine = `\nHook directive (paste before commit): ${directive}`
+    console.log(prompt + markerLine + directiveLine)
+    return
+  }
+
+  console.log(prompt + markerLine)
 }
 
 function run(args) {
@@ -109,7 +127,7 @@ async function main() {
   const role = flags.role || (cmd === 'write' ? 'draft' : 'research')
 
   if (cmd === 'research' || cmd === 'write') {
-    printPrompt(cmd, post, harness, role)
+    printPrompt(cmd, post, harness, role, flags.marker)
     return
   }
 
@@ -152,8 +170,9 @@ async function main() {
       `--role=${role}`,
       '--kind=post',
       '--attach=revision',
+      flags.marker ? `--marker=${flags.marker}` : '',
       `--note=${flags.note}`,
-    ])
+    ].filter(Boolean))
     return
   }
 

--- a/tools/harness/claude-code.ts
+++ b/tools/harness/claude-code.ts
@@ -52,6 +52,12 @@ function touchedFiles(ev: any): string[] {
   return [...out]
 }
 
+function markerInUserEvent(ev: any, marker: string): boolean {
+  if (!marker) return false
+  if (ev?.type !== 'user') return false
+  return userText(ev).includes(marker)
+}
+
 function toolSummary(ev: any): { count: number; names: string[] } {
   const content = ev?.message?.content
   if (!Array.isArray(content)) return { count: 0, names: [] }
@@ -180,6 +186,7 @@ export class ClaudeCodeHarness implements TraceHarness {
     const raw = await readFile(ref.path, 'utf8')
     const events = parseJsonl(raw)
     const wantedFiles = (filter.files ?? []).map((f) => f.replace(/^\.\//, ''))
+    const wantedTokens = wantedFiles.map((f) => f.replace(/\.mdx$/, '').replace(/\.tsx?$/, '').replace(/\.astro$/, ''))
 
     // Segment the session into user-turn windows: each window starts with a
     // user message and includes all assistant activity until the next user
@@ -201,25 +208,65 @@ export class ClaudeCodeHarness implements TraceHarness {
     }
     if (cur) windows.push(cur)
 
+    const marker = (filter.marker ?? '').trim()
     const relevant = wantedFiles.length
-      ? windows.filter((w) =>
-          w.events.some((e) =>
-            touchedFiles(e).some((t) => wantedFiles.some((wf) => t.endsWith(wf)))
-          )
-        )
-      : windows
+      ? windows
+          .map((w, i) => {
+            let related = false
+            const hasTouchedFiles = w.events.some((e) =>
+              touchedFiles(e).some((t) => wantedFiles.some((wf) => t.endsWith(wf))),
+            )
+            const mention = w.events.some((e) => {
+              if (e?.type !== 'user') return false
+              const txt = userText(e)
+              return wantedTokens.some((wf) => wf && txt.includes(wf))
+            })
+            if (hasTouchedFiles || mention) related = true
+            return { index: i, related }
+          })
+          .filter((x) => x.related)
+      : windows.map((_, i) => ({ index: i, related: true }))
+
+    const selected = new Set<number>()
+    for (const r of relevant) {
+      if (r.index > 0) selected.add(r.index - 1)
+      selected.add(r.index)
+      selected.add(r.index + 1)
+    }
+
+    const relevantWindowIndexes = [...selected]
+      .filter((i) => i >= 0 && i < windows.length)
+      .sort((a, b) => a - b)
+
+    const markerHits = windows
+      .map((w, i) => ({ i, hit: w.events.some((e) => markerInUserEvent(e, marker)) }))
+      .filter((x) => x.hit)
+      .map((x) => x.i)
+
+    let finalWindowIndexes = relevantWindowIndexes
+    if (marker && markerHits.length) {
+      const cutoff = Math.max(markerHits[markerHits.length - 1] - 1, 0)
+      finalWindowIndexes = relevantWindowIndexes.filter((i) => i >= cutoff)
+    } else if (marker && relevantWindowIndexes.length) {
+      finalWindowIndexes = relevantWindowIndexes.slice(-2)
+    }
+
+    const relevantWindows = finalWindowIndexes.map((i) => windows[i])
+
+    let seq = 0
 
     const projectRoot = (ref.cwd ?? process.cwd()).replace(/\/$/, '') + '/'
     const relativize = (p: string) => p.startsWith(projectRoot) ? p.slice(projectRoot.length) : p
 
     const turns: Turn[] = []
-    for (const w of relevant) {
+    for (const w of relevantWindows) {
       for (const e of w.events) {
         const ts: string = e?.timestamp ?? ''
         if (e?.type === 'user') {
           const txt = userText(e)
           if (!txt) continue
-          turns.push({ role: 'user', text: txt.length > 8000 ? summarize(txt, 8000) : txt, ts })
+          turns.push({ role: 'user', seq, text: txt.length > 8000 ? summarize(txt, 8000) : txt, ts })
+          seq++
         } else if (e?.type === 'assistant') {
           const txt = assistantText(e)
           const { count, names } = toolSummary(e)
@@ -232,6 +279,7 @@ export class ClaudeCodeHarness implements TraceHarness {
           const hasTools = count > 0
           if (!hasText && !hasTools) continue
           turns.push({
+            seq,
             role: 'assistant',
             text: hasText ? (txt.length > 8000 ? summarize(txt, 8000) : txt) : undefined,
             text_summary: hasText ? summarize(txt, 280) : undefined,
@@ -242,6 +290,7 @@ export class ClaudeCodeHarness implements TraceHarness {
             had_thinking: hadThinking(e) || undefined,
             ts,
           })
+          seq++
         }
       }
     }

--- a/tools/harness/codex.ts
+++ b/tools/harness/codex.ts
@@ -92,6 +92,12 @@ function roleOf(ev: any): Turn['role'] | null {
   return null
 }
 
+function markerInUserTurn(ev: any, marker: string): boolean {
+  if (!marker) return false
+  if (roleOf(ev) !== 'user') return false
+  return textOf(ev).includes(marker)
+}
+
 function textOf(ev: any): string {
   const p = payloadOf(ev)
   if (ev?.type === 'event_msg' && typeof p?.message === 'string') return p.message
@@ -200,33 +206,111 @@ export class CodexHarness implements TraceHarness {
     const raw = await readFile(ref.path, 'utf8')
     const events = parseJsonl(raw)
     const wanted = (filter.files ?? []).map((f) => f.replace(/^\.\//, ''))
-    const turns: Turn[] = []
+    const marker = (filter.marker ?? '').trim()
+
+    type Window = { events: any[]; relevant: boolean }
+    const windows: Window[] = []
+    let cur: { events: any[] } | null = null
 
     for (const ev of events) {
-      const role = roleOf(ev)
-      if (!role) continue
-      const ts = timestampOf(ev)
-      if (role === 'user') {
-        const text = textOf(ev)
-        if (!text.trim()) continue
-        turns.push({ role: 'user', text: summarize(text, 600), ts })
-      } else if (role === 'assistant') {
-        const text = textOf(ev)
-        const tools = toolCallInfo(ev)
-        if (wanted.length) {
-          const hit = tools.files.some((t) => wanted.some((w) => t.endsWith(w)))
-          if (!hit && tools.count > 0) continue
+      if (roleOf(ev) === 'user') {
+        if (cur) windows.push({ ...cur, relevant: false })
+        cur = { events: [] }
+      } else if (!cur) {
+        cur = { events: [] }
+      }
+      cur.events.push(ev)
+    }
+
+    if (cur) windows.push({ ...cur, relevant: false })
+
+    if (wanted.length) {
+      for (const w of windows) {
+        let related = false
+        for (const ev of w.events) {
+          const role = roleOf(ev)
+          if (!role) continue
+          const text = textOf(ev)
+          const tools = toolCallInfo(ev)
+          if (role === 'user' && text && wanted.some((w) => text.includes(w))) {
+            related = true
+            break
+          }
+          if (role === 'assistant' && tools.files.some((t) => wanted.some((w) => t.endsWith(w)))) {
+            related = true
+            break
+          }
         }
-        turns.push({
-          role: 'assistant',
-          text: text ? summarize(text, 8000) : undefined,
-          text_summary: text ? summarize(text, 280) : undefined,
-          tool_calls: tools.count || undefined,
-          tool_names: tools.names.length ? tools.names : undefined,
-          tool_call_details: tools.details.length ? tools.details : undefined,
-          files_touched: tools.files.length ? Array.from(new Set(tools.files)) : undefined,
-          ts,
-        })
+        w.relevant = related
+      }
+    } else {
+      for (const w of windows) w.relevant = true
+    }
+
+    const selected = new Set<number>()
+    for (let i = 0; i < windows.length; i++) {
+      if (!windows[i].relevant) continue
+      if (i > 0) selected.add(i - 1)
+      selected.add(i)
+      if (i + 1 < windows.length) selected.add(i + 1)
+    }
+
+    const markerWindowIndexes = windows
+      .map((w, i) => ({ i, hit: w.events.some((e) => markerInUserTurn(e, marker)) }))
+      .filter((x) => x.hit)
+      .map((x) => x.i)
+
+    const selectedIndexes = selected.size > 0
+      ? [...selected]
+          .filter((i) => i >= 0 && i < windows.length)
+          .sort((a, b) => a - b)
+      : windows.map((_, i) => i)
+
+    let finalWindowIndexes = selectedIndexes
+    if (marker && markerWindowIndexes.length) {
+      const cutoff = Math.max(markerWindowIndexes[markerWindowIndexes.length - 1] - 1, 0)
+      finalWindowIndexes = selectedIndexes.filter((i) => i >= cutoff)
+    } else if (marker && selectedIndexes.length) {
+      finalWindowIndexes = selectedIndexes.slice(-2)
+    }
+
+    const windowsToUse = finalWindowIndexes
+      .filter((i) => i >= 0 && i < windows.length)
+      .map((i) => windows[i])
+    const turns: Turn[] = []
+    let seq = 0
+
+    for (const w of windowsToUse) {
+      for (const ev of w.events) {
+        const role = roleOf(ev)
+        if (!role) continue
+        const ts = timestampOf(ev)
+        if (role === 'user') {
+          const text = textOf(ev)
+          if (!text.trim()) continue
+          turns.push({ role: 'user', text: summarize(text, 600), ts, seq })
+          seq++
+        } else if (role === 'assistant') {
+          const text = textOf(ev)
+          const tools = toolCallInfo(ev)
+          if (wanted.length) {
+            const hit = tools.files.some((t) => wanted.some((w) => t.endsWith(w)))
+            const wasInRelevantWindow = w.relevant
+            if (!hit && tools.count > 0 && !wasInRelevantWindow) continue
+          }
+          turns.push({
+            role: 'assistant',
+            seq,
+            text: text ? summarize(text, 8000) : undefined,
+            text_summary: text ? summarize(text, 280) : undefined,
+            tool_calls: tools.count || undefined,
+            tool_names: tools.names.length ? tools.names : undefined,
+            tool_call_details: tools.details.length ? tools.details : undefined,
+            files_touched: tools.files.length ? Array.from(new Set(tools.files)) : undefined,
+            ts,
+          })
+          seq++
+        }
       }
     }
 

--- a/tools/harness/manual.ts
+++ b/tools/harness/manual.ts
@@ -17,15 +17,17 @@ import { summarize } from './types.js'
 function parseMarkdownTranscript(raw: string): Turn[] {
   const turns: Turn[] = []
   const blocks = raw.split(/\n(?=\*\*(?:User|Assistant|System)(?:\s*\([^)]+\))?:\*\*)/i)
+  let seq = 0
   for (const block of blocks) {
     const m = block.match(/^\*\*(User|Assistant|System)(?:\s*\(([^)]+)\))?:\*\*\s*([\s\S]*)$/i)
     if (!m) continue
     const role = m[1].toLowerCase() as Turn['role']
     const body = m[3].trim()
     if (!body) continue
-    if (role === 'user') turns.push({ role: 'user', text: summarize(body, 600), ts: '' })
+    if (role === 'user') turns.push({ role: 'user', seq, text: summarize(body, 600), ts: '' })
     else if (role === 'assistant')
-      turns.push({ role: 'assistant', text_summary: summarize(body, 280), text: body.length < 600 ? body : undefined, ts: '' })
+      turns.push({ role: 'assistant', seq, text_summary: summarize(body, 280), text: body.length < 600 ? body : undefined, ts: '' })
+    seq++
   }
   return turns
 }
@@ -38,8 +40,9 @@ function parseTurns(raw: string): Turn[] {
       const arr = JSON.parse(trimmed)
       return arr
         .filter((t: any) => t?.role && (t.text || t.content))
-        .map((t: any) => ({
+        .map((t: any, index: number) => ({
           role: t.role,
+          seq: index,
           text: summarize(String(t.text ?? t.content), 600),
           ts: String(t.ts ?? ''),
         }))
@@ -49,6 +52,7 @@ function parseTurns(raw: string): Turn[] {
   }
   if (trimmed.includes('\n{') || trimmed.startsWith('{')) {
     const out: Turn[] = []
+    let seq = 0
     for (const line of trimmed.split('\n')) {
       const s = line.trim()
       if (!s) continue
@@ -56,13 +60,16 @@ function parseTurns(raw: string): Turn[] {
         const ev = JSON.parse(s)
         if (!ev.role) continue
         if (ev.role === 'user' || ev.role === 'system') {
-          out.push({ role: ev.role, text: summarize(String(ev.text ?? ev.content ?? ''), 600), ts: String(ev.ts ?? '') })
+          out.push({ role: ev.role, seq, text: summarize(String(ev.text ?? ev.content ?? ''), 600), ts: String(ev.ts ?? '') })
+          seq++
         } else if (ev.role === 'assistant') {
           out.push({
             role: 'assistant',
+            seq,
             text_summary: summarize(String(ev.text ?? ev.content ?? ''), 280),
             ts: String(ev.ts ?? ''),
           })
+          seq++
         }
       } catch {
         /* skip malformed */
@@ -71,6 +78,14 @@ function parseTurns(raw: string): Turn[] {
     if (out.length) return out
   }
   return parseMarkdownTranscript(raw)
+}
+
+function selectFromMarker(turns: Turn[], marker?: string): Turn[] {
+  const token = (marker ?? '').trim()
+  if (!token) return turns
+  const start = turns.findIndex((turn) => turn.role === 'user' && (turn.text?.includes(token) || false))
+  if (start < 0) return turns
+  return turns.slice(Math.max(start - 1, 0))
 }
 
 export class ManualHarness implements TraceHarness {
@@ -98,8 +113,9 @@ export class ManualHarness implements TraceHarness {
     ]
   }
 
-  async extractTurns(_ref: SessionRef, _filter: Filter): Promise<Turn[]> {
-    return parseTurns(this.input)
+  async extractTurns(_ref: SessionRef, filter: Filter): Promise<Turn[]> {
+    const turns = parseTurns(this.input)
+    return selectFromMarker(turns, filter.marker)
   }
 
   async detectModel(_ref: SessionRef): Promise<string | null> {

--- a/tools/harness/types.ts
+++ b/tools/harness/types.ts
@@ -20,6 +20,8 @@ export type ToolCallDetail = {
 /** A single turn of agent activity, lossy-summarized for repo storage. */
 export type Turn = {
   role: 'user' | 'assistant' | 'system' | 'tool'
+  /** Stable sequence index in the source session (0-based, when available). */
+  seq?: number
   /** Full text (no truncation). For very long content (>8k) the harness may still trim. */
   text?: string
   /** First ~280 chars of assistant prose — kept for compact list views. */
@@ -61,6 +63,8 @@ export type FindOpts = {
 export type Filter = {
   /** Only include turns that touched these files (or surrounding turns). */
   files?: string[]
+  /** Optional marker that must appear in a user turn to delimit the captured block. */
+  marker?: string
   /** Include at most this many turns; head and tail preserved. */
   maxTurns?: number
 }

--- a/tools/install-hooks.mjs
+++ b/tools/install-hooks.mjs
@@ -5,6 +5,8 @@
  * The hook runs after every commit. If MDX posts changed:
  *   - If there's a recent agent session (Claude Code / Codex), the existing
  *     trace-capture --auto path runs (records AI revision + saves trace).
+ *   - If BLOG_TRACE_POSTS is set, a forced capture run executes that target post
+ *     list with the supplied phase token.
  *   - Otherwise, the log-edit --auto path records a human revision.
  *
  * Idempotent: re-running the hook on the same commit dedups by SHA.
@@ -25,6 +27,34 @@ cd "$(git rev-parse --show-toplevel)"
 
 # Bail if HEAD didn't touch any post.
 if ! git show --name-only --pretty=format: HEAD | grep -qE '^src/content/posts/.*\\.mdx$'; then
+  exit 0
+fi
+
+# Forced trace capture via environment directive.
+BLOG_TRACE_POSTS="${BLOG_TRACE_POSTS:-}"
+BLOG_TRACE_HARNESS="${BLOG_TRACE_HARNESS:-}"
+BLOG_TRACE_ROLE="${BLOG_TRACE_ROLE:-polish}"
+BLOG_TRACE_KIND="${BLOG_TRACE_KIND:-post}"
+BLOG_TRACE_MARKER="${BLOG_TRACE_MARKER:-}"
+BLOG_TRACE_NOTE="${BLOG_TRACE_NOTE:-}"
+
+if [ -n "$BLOG_TRACE_POSTS" ]; then
+  IFS=',' read -r -a BLOG_POSTS <<< "$BLOG_TRACE_POSTS"
+  for post in "${BLOG_POSTS[@]}"; do
+    if command -v pnpm >/dev/null 2>&1; then
+      cmd=(pnpm tsx tools/trace-capture.ts capture --post="$post" --role="$BLOG_TRACE_ROLE" --kind="$BLOG_TRACE_KIND" --attach=revision --commit=HEAD)
+      if [ -n "$BLOG_TRACE_HARNESS" ]; then
+        cmd+=(--harness="$BLOG_TRACE_HARNESS")
+      fi
+      if [ -n "$BLOG_TRACE_MARKER" ]; then
+        cmd+=(--marker="$BLOG_TRACE_MARKER")
+      fi
+      if [ -n "$BLOG_TRACE_NOTE" ]; then
+        cmd+=(--note="$BLOG_TRACE_NOTE")
+      fi
+      "${cmd[@]}" 2>/dev/null || true
+    fi
+  done
   exit 0
 fi
 

--- a/tools/trace-capture.ts
+++ b/tools/trace-capture.ts
@@ -8,6 +8,7 @@
  *     [--post=<slug>] \
  *     [--role=outline|draft|rewrite|polish|diagram|review|publish|research] \
  *     [--session=<session-id>] \
+ *     [--marker="<token>"] \
  *     [--note=<one-line>] \
  *     [--commit=<sha>] \
  *     [--input=<path>]            # manual harness only
@@ -284,6 +285,7 @@ async function capture(flags: Args): Promise<void> {
   const attach = (flags.attach as string | undefined) ?? (kind === 'supporting-research' || role === 'research' ? 'supporting' : 'revision')
   const latest = Boolean(flags.latest)
   const sessionId = flags.session as string | undefined
+  const marker = typeof flags.marker === 'string' ? flags.marker.trim() : undefined
   const noteArg = flags.note as string | undefined
   const commit = (flags.commit as string | undefined) ?? (attach === 'revision' ? headCommit() ?? undefined : undefined)
 
@@ -322,6 +324,7 @@ async function capture(flags: Args): Promise<void> {
 
     const turns = await harness.extractTurns(session, {
       files: latest ? [] : [`${postSlug}.mdx`],
+      marker,
       maxTurns: 40,
     })
     if (!turns.length) {


### PR DESCRIPTION
## Summary
- Soften dark-mode colors in global tokens for lower eye strain during night usage.
- Add subtle warm gradient in dark mode body background.
- Rework homepage hero from hard two-column text layout into a narrative-first hero with action chips and a compact newest post panel.
- Update theme-color metadata to match new tone.

Closes nothing; visual polish only.